### PR TITLE
Use HTTPS to retrieve FontAwesome from CDN

### DIFF
--- a/assets/css/asciidoctor.css
+++ b/assets/css/asciidoctor.css
@@ -1,4 +1,4 @@
-@import url(http://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
+@import url(https://cdnjs.cloudflare.com/ajax/libs/font-awesome/3.2.0/css/font-awesome.css);
 /* ========================================================================== Embedded content ========================================================================== */
 /** Remove border when inside `a` element in IE 8/9. */
 img { border: 0; }


### PR DESCRIPTION
Currently, when using JBake to deploy a project web site to a website with SSL enabled, some browsers - e.g. Chrome - refuse to download non-secure content.

By using the HTTPS URL for FontAwesome CSS file from CloudFlare, users using HTTP and HTTPS should be able to use JBake with no warnings.

Another alternative would be to include a version of FontAwesome with the project instead, not using the CDN.

Thanks
Bruno